### PR TITLE
Supprimer l’injection inutile de l’EntityManager dans PlayQrGeoController

### DIFF
--- a/src/Controller/Game/PlayQrGeoController.php
+++ b/src/Controller/Game/PlayQrGeoController.php
@@ -7,7 +7,6 @@ use App\Attribute\RequireParticipant;
 use App\Classe\PublicSession;
 use App\Entity\Games\EscapeGame;
 use App\Service\MobileLinkManager;
-use Doctrine\ORM\EntityManagerInterface as EM;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,7 +19,7 @@ class PlayQrGeoController extends AbstractController
 
     #[Route('/play/{slug}/qr/regen/{step}', name: 'play_qr_geo_regen', methods: ['POST'])]
     #[RequireParticipant]
-    public function regen(Request $req, EscapeGame $eg, int $step, MobileLinkManager $mobile, EM $em): Response
+    public function regen(Request $req, EscapeGame $eg, int $step, MobileLinkManager $mobile): Response
     {
         $participant = $req->attributes->get('_participant');
         $puzzle = $eg->getPuzzleByStep($step);


### PR DESCRIPTION
## Summary
- Retire l’utilisation de `EntityManager` non utilisée de la méthode `regen`

## Testing
- `php -l src/Controller/Game/PlayQrGeoController.php`
- `vendor/bin/phpunit` *(échoue : fichier introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ca4e6238832389f6923cee6f2516