### PR TITLE
Nettoyage de la pagination du catalogue

### DIFF
--- a/src/Controller/Game/CatalogController.php
+++ b/src/Controller/Game/CatalogController.php
@@ -63,27 +63,6 @@ class CatalogController extends AbstractController
         }
 
         // pagination
-        $qbCount = clone $qb;
-        $qbCount
-            ->resetDQLPart('orderBy')   // <-- IMPORTANT
-            ->resetDQLPart('groupBy')   // au cas où
-            ->resetDQLPart('having');   // au cas où
-
-
-
-        //$qbCount->select('COUNT(e.id)');
-        //$total = (int) $qbCount->getQuery()->getSingleScalarResult();
-
-        /*$games = $qb
-            ->setFirstResult(($page - 1) * $perPage)
-            ->setMaxResults($perPage)
-            ->getQuery()->getResult();
-
-        $pages = (int) max(1, ceil($total / $perPage));
-*/
-        $perPage = 9;
-        $page    = max(1, (int) $req->query->get('page', 1));
-
         $qb->setFirstResult(($page - 1) * $perPage)
             ->setMaxResults($perPage);
 


### PR DESCRIPTION
## Summary
- retire l'ancien code de pagination commenté
- conserve une unique initialisation de `page` et `perPage`
- transmet correctement les paramètres de pagination à la vue

## Testing
- `php -l src/Controller/Game/CatalogController.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6cd9347148323ac4fe246eebf4edc